### PR TITLE
Improve travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,27 @@
+os:
+  - linux
+services:
+  - docker
 language: node_js
 node_js:
-  - v5
-  - v4
-  - '0.12'
+  - "4.2.1"
+jdk:
+  - oraclejdk8
+env:
+  global:
+  - JHIPSTER_MVN_DEP=1
+  - JHIPSTER_TRAVIS=$TRAVIS_BUILD_DIR/travis
+  - JHIPSTER_INSTALL=$JHIPSTER_TRAVIS/install
+  - JHIPSTER_SAMPLES=$JHIPSTER_TRAVIS/samples
+  - JHIPSTER_SCRIPTS=$JHIPSTER_TRAVIS/scripts
+  matrix:
+  - JHIPSTER=app-default
+  - JHIPSTER=app-gradle
+install:
+  - $JHIPSTER_INSTALL/02-install-jhipster-stack.sh
+  - $JHIPSTER_INSTALL/03-downloadDep.sh
+  - $JHIPSTER_INSTALL/04-checkVersion.sh
+script:
+  - $JHIPSTER_SCRIPTS/01-generate-project.sh
+  - $JHIPSTER_SCRIPTS/02-generate-entities.sh
+  - $JHIPSTER_SCRIPTS/03-test-swagger2markup.sh

--- a/travis/install/02-install-jhipster-stack.sh
+++ b/travis/install/02-install-jhipster-stack.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -ev
+#-------------------------------------------------------------------------------
+# Install yeoman, bower, grunt and gulp
+#-------------------------------------------------------------------------------
+npm install -g yo
+npm install -g bower
+npm install -g grunt-cli
+npm install -g gulp
+npm install -g generator-jhipster
+#-------------------------------------------------------------------------------
+# Install the latest version of generator-jhipster-swagger2markup
+#-------------------------------------------------------------------------------
+cd $TRAVIS_BUILD_DIR/
+npm install
+npm link

--- a/travis/install/03-downloadDep.sh
+++ b/travis/install/03-downloadDep.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -ev
+#-------------------------------------------------------------------------------
+# Use jhipster-travis-build that contain .m2 and node_modules
+#-------------------------------------------------------------------------------
+if [ $JHIPSTER_MVN_DEP == 1 ]; then
+  cd $TRAVIS_BUILD_DIR/
+  git clone https://github.com/jhipster/jhipster-travis-build.git
+  rm -Rf $HOME/.m2/repository/
+  mv $TRAVIS_BUILD_DIR/jhipster-travis-build/repository $HOME/.m2/
+  mv $TRAVIS_BUILD_DIR/jhipster-travis-build/node_modules/ $JHIPSTER_SAMPLES/$JHIPSTER/
+  ls -al $HOME/.m2/ $HOME/.m2/repository/ $JHIPSTER_SAMPLES/$JHIPSTER/
+#-------------------------------------------------------------------------------
+# Clone official jhipster-sample-app
+#-------------------------------------------------------------------------------
+elif [ $JHIPSTER_MVN_DEP == 2 ]; then
+  cd $TRAVIS_BUILD_DIR/
+  git clone https://github.com/jhipster/jhipster-sample-app.git
+  cd $TRAVIS_BUILD_DIR/jhipster-sample-app/
+  mvn dependency:go-offline
+#-------------------------------------------------------------------------------
+# By default, do nothing
+#-------------------------------------------------------------------------------
+else
+  echo "By default, no speedup build..."
+fi

--- a/travis/install/04-checkVersion.sh
+++ b/travis/install/04-checkVersion.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -ev
+#-------------------------------------------------------------------------------
+# Check all versions
+#-------------------------------------------------------------------------------
+java -version
+git --version
+mvn -v
+node -v
+npm -v
+bower -v
+yo --version
+grunt --version
+gulp -v
+docker version
+# docker-compose version

--- a/travis/samples/app-default/.jhipster/BankAccount.json
+++ b/travis/samples/app-default/.jhipster/BankAccount.json
@@ -1,0 +1,87 @@
+{
+    "relationships": [
+        {
+            "relationshipId": 1,
+            "relationshipName": "user",
+            "otherEntityName": "user",
+            "relationshipType": "many-to-one",
+            "otherEntityField": "login"
+        },
+        {
+            "relationshipId": 2,
+            "relationshipName": "operation",
+            "otherEntityName": "operation",
+            "relationshipType": "one-to-many",
+            "otherEntityRelationshipName": "bankAccount"
+        }
+    ],
+    "fields": [
+        {
+            "fieldId": 1,
+            "fieldName": "name",
+            "fieldType": "String",
+            "fieldValidateRules": [
+                "required"
+            ]
+        },
+        {
+            "fieldId": 2,
+            "fieldName": "bankNumber",
+            "fieldType": "Integer"
+        },
+        {
+            "fieldId": 3,
+            "fieldName": "agencyNumber",
+            "fieldType": "Long"
+        },
+        {
+            "fieldId": 4,
+            "fieldName": "lastOperationDuration",
+            "fieldType": "Float"
+        },
+        {
+            "fieldId": 5,
+            "fieldName": "meanOperationDuration",
+            "fieldType": "Double"
+        },
+        {
+            "fieldId": 6,
+            "fieldName": "balance",
+            "fieldType": "BigDecimal",
+            "fieldValidateRules": [
+                "required"
+            ]
+        },
+        {
+            "fieldId": 7,
+            "fieldName": "openingDay",
+            "fieldType": "LocalDate"
+        },
+        {
+            "fieldId": 8,
+            "fieldName": "lastOperationDate",
+            "fieldType": "ZonedDateTime"
+        },
+        {
+            "fieldId": 9,
+            "fieldName": "isActive",
+            "fieldType": "Boolean"
+        },
+        {
+            "fieldId": 10,
+            "fieldName": "accountType",
+            "fieldType": "BankAccountType",
+            "fieldValues": "CHECKING,SAVINGS,LOAN"
+        },
+        {
+            "fieldId": 11,
+            "fieldName": "attachment",
+            "fieldType": "byte[]",
+            "fieldTypeBlobContent": "any"
+        }
+    ],
+    "changelogDate": "20150805124838",
+    "dto": "no",
+    "service": "no",
+    "pagination": "no"
+}

--- a/travis/samples/app-default/.jhipster/Label.json
+++ b/travis/samples/app-default/.jhipster/Label.json
@@ -1,0 +1,28 @@
+{
+    "relationships": [
+        {
+            "relationshipId": 1,
+            "relationshipName": "operation",
+            "otherEntityName": "operation",
+            "relationshipType": "many-to-many",
+            "ownerSide": false,
+            "otherEntityRelationshipName": "label"
+        }
+    ],
+    "fields": [
+        {
+            "fieldId": 1,
+            "fieldName": "label",
+            "fieldType": "String",
+            "fieldValidateRules": [
+                "required",
+                "minlength"
+            ],
+            "fieldValidateRulesMinlength": "3"
+        }
+    ],
+    "changelogDate": "20150805124936",
+    "dto": "no",
+    "service": "no",
+    "pagination": "no"
+}

--- a/travis/samples/app-default/.jhipster/Operation.json
+++ b/travis/samples/app-default/.jhipster/Operation.json
@@ -1,0 +1,46 @@
+{
+    "relationships": [
+        {
+            "relationshipId": 1,
+            "relationshipName": "bankAccount",
+            "otherEntityName": "bankAccount",
+            "relationshipType": "many-to-one",
+            "otherEntityField": "name"
+        },
+        {
+            "relationshipId": 2,
+            "relationshipName": "label",
+            "otherEntityName": "label",
+            "relationshipType": "many-to-many",
+            "otherEntityField": "label",
+            "ownerSide": true
+        }
+    ],
+    "fields": [
+        {
+            "fieldId": 1,
+            "fieldName": "date",
+            "fieldType": "ZonedDateTime",
+            "fieldValidateRules": [
+                "required"
+            ]
+        },
+        {
+            "fieldId": 2,
+            "fieldName": "description",
+            "fieldType": "String"
+        },
+        {
+            "fieldId": 3,
+            "fieldName": "amount",
+            "fieldType": "BigDecimal",
+            "fieldValidateRules": [
+                "required"
+            ]
+        }
+    ],
+    "changelogDate": "20150805125054",
+    "dto": "no",
+    "service": "no",
+    "pagination": "no"
+}

--- a/travis/samples/app-default/.yo-rc.json
+++ b/travis/samples/app-default/.yo-rc.json
@@ -1,0 +1,24 @@
+{
+  "generator-jhipster": {
+    "baseName": "sampleDefault",
+    "packageName": "com.mycompany.myapp",
+    "packageFolder": "com/mycompany/myapp",
+    "authenticationType": "session",
+    "hibernateCache": "ehcache",
+    "clusteredHttpSession": "no",
+    "websocket": "no",
+    "databaseType": "sql",
+    "devDatabaseType": "h2Disk",
+    "prodDatabaseType": "mysql",
+    "searchEngine": "no",
+    "useSass": false,
+    "buildTool": "maven",
+    "frontendBuilder": "grunt",
+    "enableTranslation": true,
+    "enableSocialSignIn": false,
+    "rememberMeKey": "f19f0827c622eb9b81f5227a869ccd44932d78eb",
+    "testFrameworks": [
+      "gatling"
+    ]
+  }
+}

--- a/travis/samples/app-gradle/.jhipster/BankAccount.json
+++ b/travis/samples/app-gradle/.jhipster/BankAccount.json
@@ -1,0 +1,87 @@
+{
+    "relationships": [
+        {
+            "relationshipId": 1,
+            "relationshipName": "user",
+            "otherEntityName": "user",
+            "relationshipType": "many-to-one",
+            "otherEntityField": "login"
+        },
+        {
+            "relationshipId": 2,
+            "relationshipName": "operation",
+            "otherEntityName": "operation",
+            "relationshipType": "one-to-many",
+            "otherEntityRelationshipName": "bankAccount"
+        }
+    ],
+    "fields": [
+        {
+            "fieldId": 1,
+            "fieldName": "name",
+            "fieldType": "String",
+            "fieldValidateRules": [
+                "required"
+            ]
+        },
+        {
+            "fieldId": 2,
+            "fieldName": "bankNumber",
+            "fieldType": "Integer"
+        },
+        {
+            "fieldId": 3,
+            "fieldName": "agencyNumber",
+            "fieldType": "Long"
+        },
+        {
+            "fieldId": 4,
+            "fieldName": "lastOperationDuration",
+            "fieldType": "Float"
+        },
+        {
+            "fieldId": 5,
+            "fieldName": "meanOperationDuration",
+            "fieldType": "Double"
+        },
+        {
+            "fieldId": 6,
+            "fieldName": "balance",
+            "fieldType": "BigDecimal",
+            "fieldValidateRules": [
+                "required"
+            ]
+        },
+        {
+            "fieldId": 7,
+            "fieldName": "openingDay",
+            "fieldType": "LocalDate"
+        },
+        {
+            "fieldId": 8,
+            "fieldName": "lastOperationDate",
+            "fieldType": "ZonedDateTime"
+        },
+        {
+            "fieldId": 9,
+            "fieldName": "isActive",
+            "fieldType": "Boolean"
+        },
+        {
+            "fieldId": 10,
+            "fieldName": "accountType",
+            "fieldType": "BankAccountType",
+            "fieldValues": "CHECKING,SAVINGS,LOAN"
+        },
+        {
+            "fieldId": 11,
+            "fieldName": "attachment",
+            "fieldType": "byte[]",
+            "fieldTypeBlobContent": "any"
+        }
+    ],
+    "changelogDate": "20150805124838",
+    "dto": "mapstruct",
+    "service": "no",
+    "pagination": "no"
+}

--- a/travis/samples/app-gradle/.jhipster/Label.json
+++ b/travis/samples/app-gradle/.jhipster/Label.json
@@ -1,0 +1,28 @@
+{
+    "relationships": [
+        {
+            "relationshipId": 1,
+            "relationshipName": "operation",
+            "otherEntityName": "operation",
+            "relationshipType": "many-to-many",
+            "ownerSide": false,
+            "otherEntityRelationshipName": "label"
+        }
+    ],
+    "fields": [
+        {
+            "fieldId": 1,
+            "fieldName": "label",
+            "fieldType": "String",
+            "fieldValidateRules": [
+                "required",
+                "minlength"
+            ],
+            "fieldValidateRulesMinlength": "3"
+        }
+    ],
+    "changelogDate": "20150805124936",
+    "dto": "no",
+    "service": "no",
+    "pagination": "no"
+}

--- a/travis/samples/app-gradle/.jhipster/Operation.json
+++ b/travis/samples/app-gradle/.jhipster/Operation.json
@@ -1,0 +1,46 @@
+{
+    "relationships": [
+        {
+            "relationshipId": 1,
+            "relationshipName": "bankAccount",
+            "otherEntityName": "bankAccount",
+            "relationshipType": "many-to-one",
+            "otherEntityField": "name"
+        },
+        {
+            "relationshipId": 2,
+            "relationshipName": "label",
+            "otherEntityName": "label",
+            "relationshipType": "many-to-many",
+            "otherEntityField": "label",
+            "ownerSide": true
+        }
+    ],
+    "fields": [
+        {
+            "fieldId": 1,
+            "fieldName": "date",
+            "fieldType": "ZonedDateTime",
+            "fieldValidateRules": [
+                "required"
+            ]
+        },
+        {
+            "fieldId": 2,
+            "fieldName": "description",
+            "fieldType": "String"
+        },
+        {
+            "fieldId": 3,
+            "fieldName": "amount",
+            "fieldType": "BigDecimal",
+            "fieldValidateRules": [
+                "required"
+            ]
+        }
+    ],
+    "changelogDate": "20150805125054",
+    "dto": "no",
+    "service": "no",
+    "pagination": "infinite-scroll"
+}

--- a/travis/samples/app-gradle/.yo-rc.json
+++ b/travis/samples/app-gradle/.yo-rc.json
@@ -1,0 +1,24 @@
+{
+  "generator-jhipster": {
+    "baseName": "sampleGradle",
+    "packageName": "com.mycompany.myapp",
+    "packageFolder": "com/mycompany/myapp",
+    "authenticationType": "session",
+    "hibernateCache": "ehcache",
+    "clusteredHttpSession": "no",
+    "websocket": "no",
+    "databaseType": "sql",
+    "devDatabaseType": "h2Disk",
+    "prodDatabaseType": "mysql",
+    "searchEngine": "no",
+    "useSass": false,
+    "buildTool": "gradle",
+    "frontendBuilder": "grunt",
+    "enableTranslation": true,
+    "enableSocialSignIn": false,
+    "rememberMeKey": "0b557a1f94eb8ea76db0a95b5e8b64bec08bb869",
+    "testFrameworks": [
+      "gatling"
+    ]
+  }
+}

--- a/travis/scripts/01-generate-project.sh
+++ b/travis/scripts/01-generate-project.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -ev
+#-------------------------------------------------------------------------------
+# Generate the project with yo jhipster
+#-------------------------------------------------------------------------------
+mv -f $JHIPSTER_SAMPLES/$JHIPSTER $HOME/
+cd $HOME/$JHIPSTER
+rm -Rf $HOME/$JHIPSTER/node_modules/*gulp*
+npm link generator-jhipster
+yo jhipster --force --no-insight
+yo jhipster-swagger2markup default --force --no-insight
+ls -al $HOME/$JHIPSTER
+ls -al $HOME/$JHIPSTER/node_modules/generator-jhipster/
+ls -al $HOME/$JHIPSTER/node_modules/generator-jhipster/entity/

--- a/travis/scripts/02-generate-entities.sh
+++ b/travis/scripts/02-generate-entities.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -ev
+#-------------------------------------------------------------------------------
+# Generate the entities with yo jhipster:entity
+#-------------------------------------------------------------------------------
+cd $HOME/$JHIPSTER
+if [ -a .jhipster/BankAccount.json ]; then
+  yo jhipster:entity BankAccount --force --no-insight
+  if [ $JHIPSTER == "app-cassandra" ]; then
+    cat src/main/resources/config/cql/*_added_entity_BankAccount.cql >> src/main/resources/config/cql/create-tables.cql
+  fi
+fi
+if [ -a .jhipster/Label.json ]; then
+  yo jhipster:entity Label --force --no-insight
+fi
+if [ -a .jhipster/Operation.json ]; then
+  yo jhipster:entity Operation --force --no-insight
+fi

--- a/travis/scripts/03-test-swagger2markup.sh
+++ b/travis/scripts/03-test-swagger2markup.sh
@@ -6,8 +6,8 @@ set -ev
 cd $HOME/$JHIPSTER
 if [ $JHIPSTER != "app-gradle" ]; then
   mvn install
-  ls -al target/asciidoc/ target/asciidoc/html5/ target/asciidoc/pdf/
+  ls -al target/asciidoc/ target/asciidoc/html5/
 else
   ./gradlew asciidoctor
-  ls -al build/asciidoc/ build/asciidoc/html5/ build/asciidoc/pdf/
+  ls -al build/asciidoc/ build/asciidoc/html5/
 fi

--- a/travis/scripts/03-test-swagger2markup.sh
+++ b/travis/scripts/03-test-swagger2markup.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -ev
+#-------------------------------------------------------------------------------
+# Launch tests
+#-------------------------------------------------------------------------------
+cd $HOME/$JHIPSTER
+if [ $JHIPSTER != "app-gradle" ]; then
+  mvn install
+  ls -al target/asciidoc/ target/asciidoc/html5/ target/asciidoc/pdf/
+else
+  ./gradlew asciidoctor
+  ls -al build/asciidoc/ build/asciidoc/html5/ build/asciidoc/pdf/
+fi


### PR DESCRIPTION
I use the same in the main generator-jhipster

The only "issue" is that the gradle build take ~10min. It's really too long, in my opinion. As I'm beginner with Gradle, I don't know how to optimize and speed up the build for gradle.
Maybe use a new repository like jhipster-travis-build to keep all lib (~/.gradle) ? But the repository can't be over than 1Go.

Although it take time, u can see the file generated at the end of travis build log.
Feel free to merge this or not :smile: 
