### PR TITLE
adding missing spring boot actuator endpoint

### DIFF
--- a/generators/app/templates/src/test/resources/config/_application-s2m.yml
+++ b/generators/app/templates/src/test/resources/config/_application-s2m.yml
@@ -2,3 +2,5 @@ jhipster:
     swagger:
         contactName: <%=packageName%>
         contactEmail: <%=packageName%>@example.org
+management:
+    context-path: /management


### PR DESCRIPTION
Adding the missing spring boot actuator endpoint configuration in order to let the Test generate the swagger file.